### PR TITLE
Specify source version when building

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ sourceSets {
     }
 }
 
+sourceCompatibility = JavaVersion.VERSION_1_6
+
 task fatJar(type: Jar) {
     baseName = project.name + '-all'
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }


### PR DESCRIPTION
Change build.gradle to set the source compatibility as Java 1.6, to
ensure it's built to the expected version (instead of the Java version
used to build).

Ideally it should also specify the bootstrap classpath to ensure the built
classes are really compatible.