### PR TITLE
Address sonarcloud findings

### DIFF
--- a/src/com/veggiespam/imagelocationscanner/ILS.java
+++ b/src/com/veggiespam/imagelocationscanner/ILS.java
@@ -700,14 +700,16 @@ public class ILS {
 				continue;
 			}
 
-			try {
+			File f = new File(s);
+			try (FileInputStream fis = new FileInputStream(f)) {
 				System.out.print("Processing " + s + " : ");
 
-				File f = new File(s);
-				FileInputStream fis = new FileInputStream(f);
 				long size = f.length();
 				byte[] data = new byte[(int) size];
-				fis.read(data);
+				long read = fis.read(data);
+				if (read != size) {
+				    System.out.println("There was a problem reading the file");
+				}
 				fis.close();
 				
 				String res = scanForLocationInImage(data, html);


### PR DESCRIPTION
- Use try-with-resource on FileInputSteam to ensure it gets closed.
- Check the return value from the read operation.

The second one is not likely to happen, and would likely hit one of the catch blocks anyway but still seems like a good safety net anyway.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>